### PR TITLE
use flux gar workload identity auth

### DIFF
--- a/other_stuff/flux_image_policy.tf
+++ b/other_stuff/flux_image_policy.tf
@@ -19,6 +19,8 @@ resource "google_service_account_iam_binding" "flux" {
   service_account_id = google_service_account.flux.name
   role               = "roles/iam.workloadIdentityUser"
   members = [
+    # "serviceAccount:${var.gcp_project}.svc.id.goog[flux-system/gcr-credentials-sync]",
+    "serviceAccount:${var.gcp_project}.svc.id.goog[flux-system/kustomize-controller]",
     "serviceAccount:${var.gcp_project}.svc.id.goog[flux-system/source-controller]",
     "serviceAccount:${var.gcp_project}.svc.id.goog[flux-system/image-reflector-controller]",
   ]


### PR DESCRIPTION
Allow flux controller to authenticate to Google GAR via GCP Workload Identity instead of cronjob